### PR TITLE
Restrict edit to own profile and enable messaging only for others 

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -43,7 +43,7 @@
                 {
                   "type": "initial",
                   "maximumWarning": "500kB",
-                  "maximumError": "1MB"
+                  "maximumError": "1.1MB"
                 },
                 {
                   "type": "anyComponentStyle",

--- a/src/app/dialogs/dialog-user-details/dialog-user-details.component.html
+++ b/src/app/dialogs/dialog-user-details/dialog-user-details.component.html
@@ -8,7 +8,7 @@
   </div>
   <div class="d_flex_s_b">
     <b><span>{{ user.displayName }}</span></b>
-    <a (click)="openEditDialog();">Bearbeiten</a>
+    <a *ngIf="!directMessage" (click)="openEditDialog();">Bearbeiten</a>
   </div>
   <div class="status">
     <div></div>
@@ -19,12 +19,14 @@
       <img src="./assets/img/input/email.svg" alt="email" />
       <span>E-Mail Adresse</span>
     </div>
-    <a *ngIf="!user.emailVerified || !user.provider " (click)="sendMail();" class="send-button" [class.grey-send-button]="sendMailStatus">Bestätigen</a>
-    <img *ngIf="!user.emailVerified && !user.provider" (click)="openEmailDialog();" src="./assets/img/devspace/edit.png" alt="edit" />
+    <a *ngIf="!user.emailVerified || !user.provider " (click)="sendMail();" class="send-button"
+      [class.grey-send-button]="sendMailStatus">Bestätigen</a>
+    <img *ngIf="!user.emailVerified && !user.provider" (click)="openEmailDialog();" src="./assets/img/devspace/edit.png"
+      alt="edit" />
   </div>
   <a href="mailto: {{ user.email }}">{{ user.email }}</a>
-  <button *ngIf="directMessage" class="profile-message-btn">
-    <img src="./assets/img/message-icons/mode_comment.svg" alt="Nachricht" class="message-icon"/>
+  <button *ngIf="directMessage" class="profile-message-btn" (click)="closeProfilView()">
+    <img src="./assets/img/message-icons/mode_comment.svg" alt="Nachricht" class="message-icon" />
     Nachricht
   </button>
 </div>

--- a/src/app/dialogs/dialog-user-options/dialog-user-options.component.ts
+++ b/src/app/dialogs/dialog-user-options/dialog-user-options.component.ts
@@ -17,7 +17,7 @@ export class DialogUserOptionsComponent {
   private dialog = inject(MatDialog);
   private auth = inject(AuthService);
   public router = inject(RouterService);
-  
+
   /**
    * Logs the user out via the authentication service and closes the current dialog.
    *

--- a/src/app/main/message-panel/messages/single-message/single-message.component.html
+++ b/src/app/main/message-panel/messages/single-message/single-message.component.html
@@ -1,8 +1,3 @@
-<!-- <div class="message-wrapper" [ngClass]="{
-    'hover-thread-message not-own-message': !isOwnMessage(msg),
-    'hover-own-message': isOwnMessage(msg),
-    'hover-message-wrapper': hovered
-  }" (mouseenter)="onMouseEnter()" (touchstart)="onTouchStart()" (click)="closeEmojiMenu()"> -->
 <div class="message-wrapper" [ngClass]="{
     'hover-thread-message not-own-message': !isOwnMessage(msg),
     'hover-own-message': isOwnMessage(msg),
@@ -60,13 +55,6 @@
 
     </div>
     <!-- Emoji-Zeile -->
-    <!-- <div class="emoji-row" [ngClass]="{
-          'emoji-row-left-aligned': isOwnMessage(msg),
-          'emoji-row-right-aligned': !isOwnMessage(msg),
-          'make-visible': hovered,
-          'emoji-row-open scrollable': emojiMenuOpen,
-          'emoji-row-closed': !emojiMenuOpen
-        }" (click)="$event.stopPropagation()" (touchstart)="$event.stopPropagation()"> -->
     <div class="emoji-row" [ngClass]="{
           'emoji-row-left-aligned': isOwnMessage(msg),
           'emoji-row-right-aligned': !isOwnMessage(msg),

--- a/src/app/main/message-panel/messages/single-message/single-message.component.ts
+++ b/src/app/main/message-panel/messages/single-message/single-message.component.ts
@@ -236,7 +236,7 @@ export class SingleMessageComponent {
   async openUserDialog(userId: any) {
     this.activeUser = await this.firebase.searchUsersById(userId);
     const dialogDetails = this.dialog.open(DialogUserDetailsComponent);
-    dialogDetails.componentInstance.directMessage = true;
+    dialogDetails.componentInstance.directMessage = userId !== this.currentUser.id;
     dialogDetails.componentInstance.user = this.activeUser;
   }
 


### PR DESCRIPTION
This update ensures that users can only edit their own profile details in the DialogUserDetailsComponent. Additionally, the messaging option is enabled only when viewing other users' profiles.